### PR TITLE
allow for resolves/rejects to be called in series

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,12 +42,14 @@ function buildThenable() {
 function setup(sinon) {
   function resolves(value) {
     this.thenable.resolved = true;
+    this.thenable.rejected = false;
     this.thenable.resolveValue = value;
     return this;
   }
 
   function rejects(value) {
     this.thenable.rejected = true;
+    this.thenable.resolved = false;
     this.thenable.rejectValue = value;
     return this;
   }

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -115,6 +115,30 @@ describe('stubPromise', function() {
     done();
   });
 
+  it('respects resolve if resolve is last', function() {
+    promise.rejects();
+    promise.resolves();
+
+    var rejectedCalled = false;
+    promise().catch(function() {
+      rejectedCalled = true;
+    });
+
+    expect(rejectedCalled).to.be.false;
+  });
+
+  it('respects reject if reject is last', function() {
+    promise.resolves();
+    promise.rejects();
+
+    var resolveCalled = false;
+    promise().then(function() {
+      resolveCalled = true;
+    });
+
+    expect(resolveCalled).to.be.false;
+  });
+
   describe('chaining', function() {
     it('supports then chaining', function(done) {
       promise().then(f).then(f);


### PR DESCRIPTION
It is possible when writing tests that you may end up calling resolves
then rejects (or vice versa) and we should clear the alternative
behavior when this happens.