### PR TITLE
Handle when assertion error thrown in promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-
-
 function buildThenable() {
   return {
     then: function(onFulfill, onReject) {
@@ -18,6 +16,9 @@ function buildThenable() {
           return this;
         }
       } catch(error) {
+        if (error.constructor.name.match(/AssertionError/)) {
+          throw error;
+        }
         this.rejectValue = error;
         this.rejected = true;
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "node_modules/.bin/mocha spec"
   },
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^2.3.0",
     "mocha": "^2.1.0",
     "rsvp": "^3.0.16",
     "sinon": "^1.12.2"

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -1,5 +1,6 @@
 var sinon = require('sinon');
 var sinonStubPromise = require('../index');
+var AssertionError = require('chai').AssertionError;
 var expect = require('chai').expect;
 var RSVP = require('rsvp');
 
@@ -250,6 +251,18 @@ describe('stubPromise', function() {
         expect(error.message).to.eql('error');
         done();
       });
+    });
+
+    it('throws error if assertion error', function() {
+      promise.resolves();
+
+      function throwError() {
+        throw new AssertionError();
+      }
+
+      expect(function() {
+        promise().then(throwError)
+      }).to.throw(AssertionError);
     });
   });
 });


### PR DESCRIPTION
Found the culprit of chai-as-promised never failing. We need to handle `AssertionError` as a normal error an throw.