### PR TITLE
Make sure catch catches errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,8 +26,7 @@ function buildThenable() {
       }
 
       if (this.rejected && onReject) {
-        onReject(this.rejectValue);
-        return this;
+        return this.catch(onReject);
       }
       return this;
     },
@@ -35,7 +34,11 @@ function buildThenable() {
     catch: function(onReject) {
       if (this.rejected) {
         try {
-          onReject(this.rejectValue);
+          const value = onReject(this.rejectValue);
+          this.resolved = true;
+          this.rejected = false;
+          this.resolveValue = value;
+          this.rejectValue = undefined;
         } catch (e) {
           this.rejectValue = e;
         }


### PR DESCRIPTION
In this example https://tonicdev.com/570b58feacaa9d11003f795b/570b58feacaa9d11003f795c

```
promise.resolve()
    .then(() => {throw new Error()})
    .catch(() => 'no error')
    .then(a => console.log(a));
```
the `catch` method successfully catches the error and returns `'no error'` which is passed to the final `then`.

Before this diff, the second `then` would not be called.