### PR TITLE
Changed module loading code to fix issue #14

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,6 +81,15 @@ function setup(sinon) {
 
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = setup;
-} else if (window.sinon) {
-  setup(window.sinon);
+} else if (typeof window !== 'undefined') {
+	if(typeof window.sinon !== 'undefined') setup(window.sinon);
+} else {
+	if(typeof this.sinon !== 'undefined') setup(this.sinon);
 }
+
+//Another possible fixed inspired by how moment.js implements it's module creation code.
+/*(function (global, factory) {
+    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+    typeof define === 'function' && define.amd ? define(factory) :
+    global.sinonStubPromise = factory(sinon)
+}(this, setup));*/


### PR DESCRIPTION
Fixes issue #14 

On Karma when running tests under environments such as Nativescript, standard browser variables such as window and self do not exist. In this case adding the library to the 'this' variable which is the global scope is a sensible failsafe which works.

This change does not break any existing tests.

I have included an alternate way of writing the loading code as taken from [moment.js](https://github.com/moment/moment/blob/develop/moment.js). Feel free to choose which you prefer.