### PR TITLE
Synchronously call callbacks added to promise before resolves/rejects

### DIFF
--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -67,6 +67,17 @@ describe('stubPromise', function() {
 
     expect(resolved).to.be.false;
   });
+  it('does resolve synchronously when explicitly resolved AFTER a then is added', function() {
+    var resolved = false;
+
+    promise().then(function() {
+      resolved = true;
+    });
+
+    expect(resolved).to.be.false;
+    promise.resolves();
+    expect(resolved).to.be.true;
+  });
 
   it('returns stub from resolves call', function(done) {
     var stub = promise.resolves();
@@ -119,6 +130,28 @@ describe('stubPromise', function() {
     });
 
     expect(rejected).to.be.false;
+  });
+  it('can reject via catch synchronously when explicitly rejected AFTER a catch is added', function() {
+    var rejected = false;
+
+    promise().catch(function() {
+      rejected = true;
+    });
+
+    expect(rejected).to.be.false;
+    promise.rejects();
+    expect(rejected).to.be.true;
+  });
+  it('can reject via a then reject function synchronously when explicitly rejected AFTER a then reject function is added', function() {
+    var rejected = false;
+
+    promise().then(f, function() {
+      rejected = true;
+    });
+
+    expect(rejected).to.be.false;
+    promise.rejects();
+    expect(rejected).to.be.true;
   });
 
   it('returns stub from rejects call', function(done) {
@@ -177,6 +210,17 @@ describe('stubPromise', function() {
     expect(finallyCalled).to.be.true;
   });
 
+  it('invokes finally when promise is resolved after the finally is added', function() {
+    var finallyCalled = false;
+    promise().finally(function() {
+      finallyCalled = true;
+    });
+
+    expect(finallyCalled).to.be.false;
+    promise.resolves();
+    expect(finallyCalled).to.be.true;
+  });
+
   it('invokes finally when promise is rejected', function() {
     promise.rejects();
 
@@ -185,6 +229,17 @@ describe('stubPromise', function() {
       finallyCalled = true;
     });
 
+    expect(finallyCalled).to.be.true;
+  });
+
+  it('invokes finally when promise is rejected after the finally is added', function() {
+    var finallyCalled = false;
+    promise().finally(function() {
+      finallyCalled = true;
+    });
+
+    expect(finallyCalled).to.be.false;
+    promise.rejects();
     expect(finallyCalled).to.be.true;
   });
 


### PR DESCRIPTION
Useful when testing the state of something (for example dispatched actions to a flux store) before and after a promise is resolved (or rejected). Added unit tests too.

Simple example for resolved:
```
    var resolved = false;

    promise().then(function() {
      resolved = true;
    });

    expect(resolved).to.be.false;
    promise.resolves();
    expect(resolved).to.be.true;
```